### PR TITLE
Compatible with RxSwift 5.1.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "ReactiveX/RxSwift" "5.0.1"
+github "ReactiveX/RxSwift" "5.1.0"
 github "uber/RIBs" ~> 0.9

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "ReactiveX/RxSwift" "5.0.1"
+github "ReactiveX/RxSwift" "5.1.0"
 github "uber/RIBs" "v0.9.2"

--- a/RIBsTreeViewerClient/Sources/RIBsTreeViewer.swift
+++ b/RIBsTreeViewerClient/Sources/RIBsTreeViewer.swift
@@ -65,7 +65,7 @@ public class RIBsTreeViewerImpl: RIBsTreeViewer {
                 let jsonData = try JSONSerialization.data(withJSONObject: $0)
                 let jsonString = String(bytes: jsonData, encoding: .utf8)!
                 self?.webSocket.send(text: jsonString)
-            } catch let error {
+            } catch {
             }
         })
 


### PR DESCRIPTION
**Description**:
RxSwift 5.1 removes UIWebView Reactive Extensions due to [Apple's hard deprecation, starting April 2020](https://developer.apple.com/news/?id=12232019b) .

RIBs also should be compatible with RxSwift 5.1.