### PR TITLE
Phase 1: SPM manifest with RIBs-iOS 1.0 (iOS 15)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,13 @@ jobs:
           cache-dependency-path: WebSocketServer/package-lock.json
       - run: npm ci
 
+  spm:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build via Swift Package Manager
+        run: ./scripts/build-spm-package.sh
+
   ios:
     runs-on: macos-14
     steps:

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "RIBs",
-        "repositoryURL": "https://github.com/uber/RIBs.git",
+        "repositoryURL": "https://github.com/uber/RIBs-iOS.git",
         "state": {
-          "branch": "master",
-          "revision": "ffc489f00db785c8c0051678393f7aba0d52f1a4",
-          "version": null
+          "branch": null,
+          "revision": "53f7cb391d48c385730df6ce1fb95029bca9d25a",
+          "version": "1.0.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
         "state": {
           "branch": null,
-          "revision": "002d325b0bdee94e7882e1114af5ff4fe1e96afa",
-          "version": "5.1.1"
+          "revision": "132aea4f236ccadc51590b38af0357a331d51fa2",
+          "version": "6.10.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,21 +1,24 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(
     name: "RIBsTreeViewerClient",
-    platforms: [.iOS(.v13)],
+    platforms: [.iOS(.v15)],
     products: [
         .library(name: "RIBsTreeViewerClient", targets: ["RIBsTreeViewerClient"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "5.1.1"),
-        .package(url: "https://github.com/uber/RIBs.git", .branch("master")),
+        .package(url: "https://github.com/uber/RIBs-iOS.git", from: "1.0.0"),
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", "6.9.0"..<"7.0.0"),
     ],
     targets: [
         .target(
             name: "RIBsTreeViewerClient",
-            dependencies: ["RxSwift", "RxCocoa", "RIBs"],
-            path: "./RIBsTreeViewerClient/Sources"
-        )
+            dependencies: [
+                .product(name: "RIBs", package: "RIBs-iOS"),
+                .product(name: "RxSwift", package: "RxSwift"),
+            ],
+            path: "RIBsTreeViewerClient/Sources"
+        ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ Add the xcframework to your project。
 ./Products/RIBsTreeViewerClient.xcframework
 ```
 
+### Swift Package Manager (in progress)
+
+SPM integration is being rolled out in [#38](https://github.com/srea/RIBsTreeViewerClient/issues/38). For local development of this repo:
+
+```swift
+// Package.swift dependency (consumer apps)
+.package(url: "https://github.com/srea/RIBsTreeViewerClient.git", from: "1.0.7"),
+```
+
+Or add this package in Xcode via **File → Add Package Dependencies** (once a tagged release includes SPM support).
+
+Requirements when using SPM: **iOS 15+**, [RIBs-iOS](https://github.com/uber/RIBs-iOS) 1.0+, RxSwift 6.x.
+
 ### CocoaPods
 
 This is not supported because the RIBs do not provide an up-to-date PodSpec, making it difficult to resolve dependencies.
@@ -34,7 +47,7 @@ github "srea/RIBsTreeViewerClient"
 $ make setup
 ```
 
-Requires Xcode 15+ and [Carthage](https://github.com/Carthage/Carthage). Dependencies are built as XCFrameworks (Apple Silicon–compatible). Minimum iOS: **13.0**.
+Requires Xcode 15+ and [Carthage](https://github.com/Carthage/Carthage). Dependencies are built as XCFrameworks (Apple Silicon–compatible). Minimum iOS: **13.0** (library source targets **15.0+** when using SPM — see [#38](https://github.com/srea/RIBsTreeViewerClient/issues/38)).
 
 To regenerate the prebuilt `Products/RIBsTreeViewerClient.xcframework` after source changes:
 
@@ -86,7 +99,7 @@ import RIBsTreeViewerClient
 
 extension AppDelegate {
     private func startRIBsTreeViewer(launchRouter: Routing) {
-        if #available(iOS 13.0, *) {
+        if #available(iOS 15.0, *) {
             ribsTreeViewer = RIBsTreeViewerImpl.init(router: launchRouter,
                                                      options: [.webSocketURL("ws://0.0.0.0:8080"),
                                                                .monitoringIntervalMillis(1000)])

--- a/RIBsTreeViewerClient/Sources/RIBsTreeViewer.swift
+++ b/RIBsTreeViewerClient/Sources/RIBsTreeViewer.swift
@@ -22,7 +22,7 @@ public enum RIBsTreeViewerOption {
     case monitoringIntervalMillis(Int)
 }
 
-@available(iOS 13.0, *)
+@available(iOS 15.0, *)
 public class RIBsTreeViewerImpl: RIBsTreeViewer {
 
     private let router: Routing
@@ -109,7 +109,7 @@ public class RIBsTreeViewerImpl: RIBsTreeViewer {
     }
 }
 
-@available(iOS 13.0, *)
+@available(iOS 15.0, *)
 extension RIBsTreeViewerImpl {
     private func captureView(from targetRouter: String) -> Data? {
         guard let router = findRouter(target: targetRouter, router: router) as? ViewableRouting,
@@ -132,7 +132,7 @@ extension RIBsTreeViewerImpl {
     }
 }
 
-@available(iOS 13.0, *)
+@available(iOS 15.0, *)
 extension RIBsTreeViewerImpl: WebSocketClientDelegate {
     func onConnected(client: WebSocketClient) {
     }
@@ -157,19 +157,19 @@ extension RIBsTreeViewerImpl: WebSocketClientDelegate {
 }
 
 protocol WebSocketClientDelegate: AnyObject {
-    @available(iOS 13.0, *)
+    @available(iOS 15.0, *)
     func onConnected(client: WebSocketClient)
-    @available(iOS 13.0, *)
+    @available(iOS 15.0, *)
     func onDisconnected(client: WebSocketClient)
-    @available(iOS 13.0, *)
+    @available(iOS 15.0, *)
     func onMessage(client: WebSocketClient, text: String)
-    @available(iOS 13.0, *)
+    @available(iOS 15.0, *)
     func onMessage(client: WebSocketClient, data: Data)
-    @available(iOS 13.0, *)
+    @available(iOS 15.0, *)
     func onError(client: WebSocketClient, error: Error)
 }
 
-@available(iOS 13.0, *)
+@available(iOS 15.0, *)
 class WebSocketClient: NSObject {
 
     weak var delegate: WebSocketClientDelegate?
@@ -239,7 +239,7 @@ class WebSocketClient: NSObject {
 
 }
 
-@available(iOS 13.0, *)
+@available(iOS 15.0, *)
 extension WebSocketClient: URLSessionWebSocketDelegate {
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
         self.delegate?.onConnected(client: self)

--- a/scripts/build-spm-package.sh
+++ b/scripts/build-spm-package.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Build RIBsTreeViewerClient via Swift Package Manager (iOS Simulator).
+# See https://github.com/srea/RIBsTreeViewerClient/issues/38
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+swift package resolve
+
+SDK="$(xcrun --sdk iphonesimulator --show-sdk-path)"
+swift build \
+  --build-path .build/spm-check \
+  -Xswiftc -sdk -Xswiftc "$SDK" \
+  -Xswiftc -target -Xswiftc arm64-apple-ios15.0-simulator \
+  -Xcc -isysroot -Xcc "$SDK" \
+  -Xcc -target -Xcc arm64-apple-ios15.0-simulator
+
+echo "SPM build succeeded (RIBsTreeViewerClient for iOS Simulator)"


### PR DESCRIPTION
Part of #38 (Carthage → SPM migration).

## Phase 1 scope

- [x] `Package.swift`: [RIBs-iOS](https://github.com/uber/RIBs-iOS) **1.0.0**, RxSwift **6.10.x**, iOS **15+**
- [x] Source: `@available(iOS 15.0)` aligned with RIBs-iOS 1.0
- [x] `Package.resolved` checked in
- [x] `scripts/build-spm-package.sh` — iOS Simulator build via SPM
- [x] CI: new **`spm`** job (existing Carthage **`ios`** job unchanged)

## Not in this PR (later phases)

- Phase 2: Remove Carthage from `.xcodeproj` / switch CI `ios` job to SPM
- Phase 3: Regenerate `Products/*.xcframework` from SPM build
- Phase 4: Delete Cartfile, patch scripts, Carthage Makefile targets

## Verify locally

```bash
./scripts/build-spm-package.sh
```